### PR TITLE
Fix Resource folder not found in some environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,5 +65,10 @@ add_executable(EGC ${CPPSources})
 target_link_libraries(EGC m GL GLEW glfw assimp components)
 
 
-add_custom_target(link_target ALL
-                COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/Resources ${CMAKE_BINARY_DIR}/Resources)
+# Copy resources to bin tree
+add_custom_target(copy_resources ALL
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/Resources" "${PROJECT_BINARY_DIR}/Resources"
+        COMMENT "Copying resources to build tree"
+        VERBATIM)
+
+add_dependencies(EGC copy_resources)


### PR DESCRIPTION
Some IDE's default to building binary artifacts in another folder and running them there. For example, CLion builds and runs executables in `${PROJECT_SRC_DIR}/cmake-build-debug`. 

The application expects to be run in the same folder with `Resources` . When the current directory does not contain `Resources` folder, the application cannot continue.

Previous solution symlink'd the `Resource` folder. It does not work when the project resides in an exFAT, FAT32 or NTFS < 3.1 partition, as they do not support symlinks.

A more robust solution modifies CMake configuration to copy `Resources` to `${PROJECT_BINARY_DIR}` when building the application.