### PR TITLE
Solve some minor CMake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ link_directories(${COMPONENT_LIB})
 include_directories(${SOURCE_SUBDIRS})
 
 file(GLOB_RECURSE CPPSources *.cpp)
+# Including CMake sources might prevent us from building the executable.
+list(FILTER CPPSources EXCLUDE REGEX CMakeFiles/*)
 
 # Remove strings matching given regular expression from a list.
 # @param(in,out) aItems Reference of a list variable to filter.
@@ -66,4 +68,5 @@ target_link_libraries(EGC m GL GLEW glfw assimp components)
 
 
 add_custom_target(link_target ALL
-                COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/Resources ${CMAKE_BINARY_DIR}/Resources)
+                COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/Resources ${CMAKE_BINARY_DIR}/Resources
+                COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_SOURCE_DIR}/Source ${CMAKE_BINARY_DIR}/Source)


### PR DESCRIPTION
I encountered a couple of issues when trying to build the project on Ubuntu 20.04, with CMake 3.16.

Some of the labs (6-9) require loading custom shaders, which reside in the `Source` directory.
The program would crash immediately when trying to run any of these labs.
I added a symlink to this directory, similar to the one to `Resources`.

I also removed CMake source files from our list of C++ sources.
The `CMakeFiles` folder contained a source used for figuring out which compiler I used, and it introduced another `main` function.
This was an issue only when trying to build "manually" in the terminal (CLion did not have this problem).