### PR TITLE
Change pacman flags for arch dependencies

### DIFF
--- a/deps-arch.sh
+++ b/deps-arch.sh
@@ -3,12 +3,12 @@
 # Run this script as root, obviously
 
 # Should already be installed
-# pacman -Sy base-devel
+# pacman -Syu base-devel
 
 # It's assumed a functional graphics driver is installed and in-use, also X11
 # If glxgears works, you should be fine
 # https://wiki.archlinux.org/index.php/xorg
-pacman -Sy cmake assimp glm glew glfw-x11 mesa lib32-mesa
+pacman -Syu cmake assimp glm glew glfw-x11 mesa lib32-mesa
 
 # For proprietary nvidia drivers
-# pacman -Sy nvidia-utils lib32-nvidia-utils
+# pacman -Syu nvidia-utils lib32-nvidia-utils


### PR DESCRIPTION
Change pacman flags to -Syu. Using -Sy is not recommended nor supported (https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported)