### PR TITLE
updated pacman flags for arch linux related scripts

### DIFF
--- a/docs/dev/running_on_wsl2.md
+++ b/docs/dev/running_on_wsl2.md
@@ -57,13 +57,13 @@ Follow these steps:
     ```sh
     sudo apt update                         # Debian (Ubuntu)
     sudo dnf check-update                   # Red Hat (Fedora)
-    sudo pacman -Syy                        # Arch (x86_64)
+    sudo pacman -Syu                        # Arch (x86_64)
     ```
 5.  Install `xinit`:
     ```sh
     sudo apt install -y xinit              # Debian (Ubuntu)
     sudo dnf -y install xinit              # Red Hat (Fedora)
-    sudo pacman -Sy xorg-xinit             # Arch (x86_64)
+    sudo pacman -S xorg-xinit             # Arch (x86_64)
     ```
 
 
@@ -90,7 +90,7 @@ Follow these steps:
         ```sh
         sudo apt install -y mesa-utils      # Debian (Ubuntu)
         sudo dnf -y install glx-utils       # Red Hat (Fedora)
-        sudo pacman -Sy mesa-demos          # Arch (x86_64)
+        sudo pacman -S mesa-demos          # Arch (x86_64)
 
         glxgears
         ```
@@ -167,8 +167,7 @@ Use the following instructions as a starting point:
     ```
 6.  Install basic stuff:
     ```sh
-    pacman -Syu
-    pacman -Sy base-devel
+    pacman -Syu base-devel
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
     locale-gen
     ```

--- a/tools/deps-arch.sh
+++ b/tools/deps-arch.sh
@@ -16,15 +16,15 @@
 
 
 # Update package lists
-sudo pacman -Syy
+sudo pacman -Syu
 
 # Install basic development tools
 # Contents: https://archlinux.org/groups/x86_64/base-devel/
-sudo pacman -Sy base-devel
+sudo pacman -Syu base-devel
 
 # Install graphics drivers and utilities, including glxinfo and glxgears.
 # For 32-bit application support, also install the `lib32-*` packages.
-sudo pacman -Sy mesa mesa-demos
+sudo pacman -Syu mesa mesa-demos
 
 # Install required dependencies
-sudo pacman -Sy cmake assimp glm glew glfw-x11 spdlog freetype2 pkgconf
+sudo pacman -Syu cmake assimp glm glew glfw-x11 spdlog freetype2 pkgconf

--- a/tools/deps-arch.sh
+++ b/tools/deps-arch.sh
@@ -20,11 +20,11 @@ sudo pacman -Syu
 
 # Install basic development tools
 # Contents: https://archlinux.org/groups/x86_64/base-devel/
-sudo pacman -Syu base-devel
+sudo pacman -S base-devel
 
 # Install graphics drivers and utilities, including glxinfo and glxgears.
 # For 32-bit application support, also install the `lib32-*` packages.
-sudo pacman -Syu mesa mesa-demos
+sudo pacman -S mesa mesa-demos
 
 # Install required dependencies
-sudo pacman -Syu cmake assimp glm glew glfw-x11 spdlog freetype2 pkgconf
+sudo pacman -S cmake assimp glm glew glfw-x11 spdlog freetype2 pkgconf


### PR DESCRIPTION
Subsequent pacman commands after an update (-Syu) only need -S, since the latest repositories have already been fetched.