### PR TITLE
Solved Fedora Wayland bug

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -19,11 +19,14 @@ WindowObject* Engine::Init(const WindowProperties & props)
 
     glewExperimental = true;
     GLenum err = glewInit();
-    if (GLEW_OK != err)
+    
+    // Allow GLEW_ERROR_NO_GLX_DISPLAY (4) on Wayland/EGL
+    // Issue: https://github.com/thliebig/AppCSXCAD/issues/11
+    if (GLEW_OK != err && err != 4)
     {
         // Serious problem
-        fprintf(stderr, "Error: %s\n", glewGetErrorString(err));
-        exit(0);
+        fprintf(stderr, "GLEW Error %u: %s\n", err, glewGetErrorString(err));
+        exit(1);
     }
 
     TextureManager::Init(window->props.selfDir);

--- a/src/core/window/window_object.cpp
+++ b/src/core/window/window_object.cpp
@@ -149,7 +149,16 @@ void WindowObject::DisablePointer()
 void WindowObject::SetWindowPosition(glm::ivec2 position)
 {
     props.position = position;
+#if defined(__unix__)
+    // On Wayland, setting window position is not supported
+    const char *waylandDisplay = getenv("WAYLAND_DISPLAY");
+    if (!waylandDisplay)
+    {
+        glfwSetWindowPos(window->handle, position.x, position.y);
+    }
+#else
     glfwSetWindowPos(window->handle, position.x, position.y);
+#endif
 }
 
 
@@ -211,7 +220,8 @@ void WindowObject::FullScreen()
 
 void error_callback(int error, const char* description)
 {
-    fprintf(stderr, "Error: %s\n", description);
+  // Print all other errors for debugging
+    fprintf(stderr, "GLFW Error %d: %s\n", error, description);
 }
 
 


### PR DESCRIPTION
## Summary
Replicated the latest issue. When running the framework inside a Wayland session (in this case Fedora 42 under WSL with a Wayland compositor) two runtime issues occured.
- GLFW reports an error when the application calls `glfwSetWindowPos` because Wayland compositors control window placement and clients are not allowed to set exact window positions. This causes an error to be logged/raised when setting window position.
- GLEW initialization reports `GLEW Error 4: Unknown error` during context initialization. This is a transient error observed on Wayland in some setups and (per upstream issue reports) can be safely ignored.

<img width="1156" height="112" alt="ReplicareEroare" src="https://github.com/user-attachments/assets/8692fedb-6e5c-4a61-80da-becfef974f3d" />


## Solution
1. Applied a check in `WindowObject::SetWindowPosition` to skip calling `glfwSetWindowPos` when Wayland is in use.
2. Ignored the GLEW error as this [forum entry](https://github.com/thliebig/AppCSXCAD/issues/11) says.

## Testing performed
Build and run with no problem in the same environment after the changes.
 
