### PR TITLE
Fix window resolution scaling

### DIFF
--- a/src/core/window/window_object.cpp
+++ b/src/core/window/window_object.cpp
@@ -432,7 +432,7 @@ glm::ivec2 WindowObject::GetResolution(bool unscaled) const
 
     if (unscaled == false)
     {
-        resolution *= props.scaleFactor;
+        resolution = glm::vec2{resolution} / props.scaleFactor;
     }
 
     return resolution;


### PR DESCRIPTION
This PR enables fractional scaling of the framebuffer size when reading the resolution from WindowObject.

In GLM, `operator*=(glm::ivec2 v, U scalar)` casts `scalar` to `int` before multiplying the coordinates of `v` by `scalar`, so the scaling factor ends up truncated. The solution is simply to convert the resolution to `vec2` and back.

Also, resolution should be divided, as opposed to multiplied, by `props.scaleFactor`, since `props.scaleFactor` is `frameBufferWidth (a.k.a. resolution.x) / width`.